### PR TITLE
Clear auth before reconnecting on session expiration

### DIFF
--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -63,7 +63,7 @@ class WhatsAppService {
           // Check if it's a 401 error (session expired)
           if (lastDisconnect?.error?.output?.statusCode === 401) {
             console.log('Session expired, clearing auth and starting fresh...');
-            // Clear the auth directory and restart
+            this.clearAuth();
             setTimeout(() => this.connect(), 5000);
           } else if (shouldReconnect) {
             setTimeout(() => this.connect(), 3000);


### PR DESCRIPTION
## Summary
- Clear authentication directory before attempting to reconnect after a session expiration to prevent stale credentials.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test-api` *(fails: Cannot find module 'test-api.js')*

------
https://chatgpt.com/codex/tasks/task_e_6899a49728908326a3c120c96caf0a1c