### PR TITLE
Fix session expiration reconnect loop

### DIFF
--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -64,6 +64,7 @@ class WhatsAppService {
           if (lastDisconnect?.error?.output?.statusCode === 401) {
             console.log('Session expired, clearing auth and starting fresh...');
             // Clear the auth directory and restart
+            this.clearAuth();
             setTimeout(() => this.connect(), 5000);
           } else if (shouldReconnect) {
             setTimeout(() => this.connect(), 3000);


### PR DESCRIPTION
## Summary
- Clear auth directory before reconnecting when WhatsApp session expires to avoid reconnect loops

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899a2e2ab1c8326955ec4458672c3fb