### PR TITLE
Preserve WhatsApp session on shutdown

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -50,10 +50,10 @@ module.exports = (whatsappService, messageQueue) => {
     });
   });
 
-  // Disconnect WhatsApp
+  // Disconnect WhatsApp and clear session
   router.post('/disconnect', async (req, res) => {
     try {
-      await whatsappService.disconnect();
+      await whatsappService.logout();
       res.json({
         success: true,
         message: 'WhatsApp disconnected successfully'

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -183,7 +183,23 @@ class WhatsAppService {
 
   async disconnect() {
     if (this.socket) {
+      try {
+        // Close the connection without logging out so credentials remain valid
+        this.socket.ws.close();
+      } catch (err) {
+        console.error('Error closing WhatsApp socket:', err);
+      }
+      this.socket = null;
+      this.isConnected = false;
+      this.qrCode = null;
+      this.io.emit('connection-status', { status: 'disconnected' });
+    }
+  }
+
+  async logout() {
+    if (this.socket) {
       await this.socket.logout();
+      this.clearAuth();
       this.socket = null;
       this.isConnected = false;
       this.qrCode = null;


### PR DESCRIPTION
## Summary
- avoid logging out on server shutdown to keep session credentials
- add explicit logout method and route to clear session when requested

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899cc8f7484832695818b34818387fd