### PR TITLE
feat(queue): support configurable delay per message

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Buka `http://localhost:PORT` untuk memindai QR dan menghubungkan akun WhatsApp.
 | GET    | `/api/messages`    | Riwayat pesan (butuh API key, opsi `limit`) |
 | GET    | `/api/queue-stats` | Statistik antrean pesan (butuh API key) |
 
+`send-private` dan `send-group` mendukung parameter opsional `delay` dalam milidetik
+untuk mengatur jeda eksekusi pesan pada antrean. Jika tidak diberikan, nilai
+default adalah `500` ms.
+
 ## Testing
 ```bash
 npm test

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,7 +1,7 @@
 const express = require('express');
-const router = express.Router();
 
 module.exports = (whatsappService, messageQueue) => {
+  const router = express.Router();
   // Middleware to validate API key
   const validateApiKey = async (req, res, next) => {
     const apiKey = req.body.apiKey || req.headers['x-api-key'];
@@ -69,7 +69,7 @@ module.exports = (whatsappService, messageQueue) => {
 
   // Send private message
   router.post('/send-private', validateApiKey, async (req, res) => {
-    const { number, message } = req.body;
+    const { number, message, delay } = req.body;
 
     if (!number || !message) {
       return res.status(400).json({
@@ -91,7 +91,8 @@ module.exports = (whatsappService, messageQueue) => {
       const result = await messageQueue.addPrivateMessage({
         number,
         message,
-        messageId
+        messageId,
+        delay: parseInt(delay) || 500
       });
 
       res.json({
@@ -114,7 +115,7 @@ module.exports = (whatsappService, messageQueue) => {
 
   // Send group message
   router.post('/send-group', validateApiKey, async (req, res) => {
-    const { groupId, message } = req.body;
+    const { groupId, message, delay } = req.body;
 
     if (!groupId || !message) {
       return res.status(400).json({
@@ -136,7 +137,8 @@ module.exports = (whatsappService, messageQueue) => {
       const result = await messageQueue.addGroupMessage({
         groupId,
         message,
-        messageId
+        messageId,
+        delay: parseInt(delay) || 500
       });
 
       res.json({

--- a/services/messageQueue.js
+++ b/services/messageQueue.js
@@ -107,9 +107,9 @@ class MessageQueue {
         message: data.message,
         messageId: data.messageId
       };
-      
+
       const job = await this.privateMessageQueue.add('send-private-message', cleanData, {
-        delay: 1000 // 1 second delay to prevent spam
+        delay: data.delay || 500
       });
       return { jobId: job.id };
     } catch (error) {
@@ -142,9 +142,9 @@ class MessageQueue {
         message: data.message,
         messageId: data.messageId
       };
-      
+
       const job = await this.groupMessageQueue.add('send-group-message', cleanData, {
-        delay: 1000 // 1 second delay to prevent spam
+        delay: data.delay || 500
       });
       return { jobId: job.id };
     } catch (error) {
@@ -185,7 +185,7 @@ class MessageQueue {
           await this.dbService.updateMessageStatus(data.messageId, 'failed');
         }
       }
-    }, 1000);
+    }, data.delay || 500);
 
     return { success: true, method: 'in-memory' };
   }

--- a/services/simpleMessageQueue.js
+++ b/services/simpleMessageQueue.js
@@ -12,9 +12,11 @@ class SimpleMessageQueue {
   }
 
   async addPrivateMessage(data) {
+    const { delay = 500, ...rest } = data;
     this.queue.push({
       type: 'private',
-      data: data,
+      data: rest,
+      delay,
       timestamp: Date.now()
     });
 
@@ -26,9 +28,11 @@ class SimpleMessageQueue {
   }
 
   async addGroupMessage(data) {
+    const { delay = 500, ...rest } = data;
     this.queue.push({
       type: 'group',
-      data: data,
+      data: rest,
+      delay,
       timestamp: Date.now()
     });
 
@@ -51,7 +55,7 @@ class SimpleMessageQueue {
       
       try {
         // Add delay to prevent spam
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await new Promise(resolve => setTimeout(resolve, item.delay));
 
         if (item.type === 'private') {
           await this.sendPrivateMessage(item.data);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -39,13 +39,28 @@ describe('API endpoints', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  test('POST /api/send-private queues message', async () => {
+  test('POST /api/send-private queues message with default delay', async () => {
     const res = await request(app)
       .post('/api/send-private')
       .send({ apiKey: 'key', number: '123', message: 'hi' });
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.message).toBe('Private message queued successfully');
+    expect(messageQueue.addPrivateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 500 })
+    );
+  });
+
+  test('POST /api/send-private queues message with custom delay', async () => {
+    const res = await request(app)
+      .post('/api/send-private')
+      .send({ apiKey: 'key', number: '123', message: 'hi', delay: 2000 });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Private message queued successfully');
+    expect(messageQueue.addPrivateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 2000 })
+    );
   });
 
   test('POST /api/send-group requires API key', async () => {
@@ -55,13 +70,28 @@ describe('API endpoints', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  test('POST /api/send-group queues message', async () => {
+  test('POST /api/send-group queues message with default delay', async () => {
     const res = await request(app)
       .post('/api/send-group')
       .send({ apiKey: 'key', groupId: 'group1', message: 'hi' });
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.message).toBe('Group message queued successfully');
+    expect(messageQueue.addGroupMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 500 })
+    );
+  });
+
+  test('POST /api/send-group queues message with custom delay', async () => {
+    const res = await request(app)
+      .post('/api/send-group')
+      .send({ apiKey: 'key', groupId: 'group1', message: 'hi', delay: 2000 });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Group message queued successfully');
+    expect(messageQueue.addGroupMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 2000 })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- allow send-private and send-group APIs to accept an optional `delay` parameter
- propagate delay through queue processors with 500ms default
- document delay option and add tests for default and custom delays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f6d009d08326b70515bbb56dbafe