### PR TITLE
Use DELAY_QUEUE env var for queue delay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ DATABASE_PATH=./database.sqlite
 
 # API Configuration
 DEFAULT_API_KEY=tes123
+DELAY_QUEUE=500

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Atur variabel lingkungan sesuai kebutuhan:
 | `PORT`       | `3000`    | Port server HTTP       |
 | `REDIS_HOST` | `localhost` | Host Redis            |
 | `REDIS_PORT` | `6379`    | Port Redis             |
+| `DELAY_QUEUE`| `500`     | Jeda antar pesan (ms)  |
 
 Saat pertama kali berjalan, database akan membuat API key bawaan `tes123`.
 
@@ -48,9 +49,9 @@ Buka `http://localhost:PORT` untuk memindai QR dan menghubungkan akun WhatsApp.
 | GET    | `/api/messages`    | Riwayat pesan (butuh API key, opsi `limit`) |
 | GET    | `/api/queue-stats` | Statistik antrean pesan (butuh API key) |
 
-`send-private` dan `send-group` mendukung parameter opsional `delay` dalam milidetik
-untuk mengatur jeda eksekusi pesan pada antrean. Jika tidak diberikan, nilai
-default adalah `500` ms.
+`send-private` dan `send-group` akan menjeda eksekusi pesan sesuai nilai
+`DELAY_QUEUE` (milidetik). Jika variabel ini tidak disetel, nilai default adalah
+`500` ms.
 
 ## Testing
 ```bash

--- a/routes/api.js
+++ b/routes/api.js
@@ -69,7 +69,7 @@ module.exports = (whatsappService, messageQueue) => {
 
   // Send private message
   router.post('/send-private', validateApiKey, async (req, res) => {
-    const { number, message, delay } = req.body;
+    const { number, message } = req.body;
 
     if (!number || !message) {
       return res.status(400).json({
@@ -92,7 +92,7 @@ module.exports = (whatsappService, messageQueue) => {
         number,
         message,
         messageId,
-        delay: parseInt(delay) || 500
+        delay: parseInt(process.env.DELAY_QUEUE) || 500
       });
 
       res.json({
@@ -115,7 +115,7 @@ module.exports = (whatsappService, messageQueue) => {
 
   // Send group message
   router.post('/send-group', validateApiKey, async (req, res) => {
-    const { groupId, message, delay } = req.body;
+    const { groupId, message } = req.body;
 
     if (!groupId || !message) {
       return res.status(400).json({
@@ -138,7 +138,7 @@ module.exports = (whatsappService, messageQueue) => {
         groupId,
         message,
         messageId,
-        delay: parseInt(delay) || 500
+        delay: parseInt(process.env.DELAY_QUEUE) || 500
       });
 
       res.json({

--- a/services/messageQueue.js
+++ b/services/messageQueue.js
@@ -109,7 +109,7 @@ class MessageQueue {
       };
 
       const job = await this.privateMessageQueue.add('send-private-message', cleanData, {
-        delay: data.delay || 500
+        delay: data.delay !== undefined ? data.delay : (parseInt(process.env.DELAY_QUEUE) || 500)
       });
       return { jobId: job.id };
     } catch (error) {
@@ -144,7 +144,7 @@ class MessageQueue {
       };
 
       const job = await this.groupMessageQueue.add('send-group-message', cleanData, {
-        delay: data.delay || 500
+        delay: data.delay !== undefined ? data.delay : (parseInt(process.env.DELAY_QUEUE) || 500)
       });
       return { jobId: job.id };
     } catch (error) {
@@ -185,7 +185,7 @@ class MessageQueue {
           await this.dbService.updateMessageStatus(data.messageId, 'failed');
         }
       }
-    }, data.delay || 500);
+    }, data.delay !== undefined ? data.delay : (parseInt(process.env.DELAY_QUEUE) || 500));
 
     return { success: true, method: 'in-memory' };
   }

--- a/services/simpleMessageQueue.js
+++ b/services/simpleMessageQueue.js
@@ -12,7 +12,7 @@ class SimpleMessageQueue {
   }
 
   async addPrivateMessage(data) {
-    const { delay = 500, ...rest } = data;
+    const { delay = parseInt(process.env.DELAY_QUEUE) || 500, ...rest } = data;
     this.queue.push({
       type: 'private',
       data: rest,
@@ -28,7 +28,7 @@ class SimpleMessageQueue {
   }
 
   async addGroupMessage(data) {
-    const { delay = 500, ...rest } = data;
+    const { delay = parseInt(process.env.DELAY_QUEUE) || 500, ...rest } = data;
     this.queue.push({
       type: 'group',
       data: rest,

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -8,6 +8,7 @@ describe('API endpoints', () => {
   let messageQueue;
 
   beforeEach(() => {
+    delete process.env.DELAY_QUEUE;
     whatsappService = {
       getConnectionStatus: jest.fn().mockReturnValue('connected'),
       dbService: {
@@ -51,10 +52,11 @@ describe('API endpoints', () => {
     );
   });
 
-  test('POST /api/send-private queues message with custom delay', async () => {
+  test('POST /api/send-private uses DELAY_QUEUE env variable', async () => {
+    process.env.DELAY_QUEUE = '2000';
     const res = await request(app)
       .post('/api/send-private')
-      .send({ apiKey: 'key', number: '123', message: 'hi', delay: 2000 });
+      .send({ apiKey: 'key', number: '123', message: 'hi' });
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.message).toBe('Private message queued successfully');
@@ -82,10 +84,11 @@ describe('API endpoints', () => {
     );
   });
 
-  test('POST /api/send-group queues message with custom delay', async () => {
+  test('POST /api/send-group uses DELAY_QUEUE env variable', async () => {
+    process.env.DELAY_QUEUE = '2000';
     const res = await request(app)
       .post('/api/send-group')
-      .send({ apiKey: 'key', groupId: 'group1', message: 'hi', delay: 2000 });
+      .send({ apiKey: 'key', groupId: 'group1', message: 'hi' });
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.message).toBe('Group message queued successfully');


### PR DESCRIPTION
## Summary
- derive message delay from `DELAY_QUEUE` environment variable with 500ms default
- remove request `delay` parameter
- document `DELAY_QUEUE` in README and env example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a060c73b88326afbb377e3c2d8e52